### PR TITLE
Implemented cocktail search

### DIFF
--- a/api/cocktails.ts
+++ b/api/cocktails.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 
 import {
   COCKTAIL_DETAILS_ENDPOINT,
+  COCKTAIL_SEARCH_ENDPOINT,
   RANDOM_COCKTAIL_ENDPOINT,
 } from "./constants";
 import { CocktailSearchResult } from "@/types";
@@ -75,5 +76,22 @@ export const fetchCocktailDetails = async (
     return { data: cocktail };
   } catch {
     return { error: "Error retrieving cocktail" };
+  }
+};
+
+// Get cocktails by search term
+export const searchCocktails = async (value: string) => {
+  try {
+    const searchUrl = `${COCKTAIL_SEARCH_ENDPOINT}?s=${value}`;
+
+    const response = await axios.get(searchUrl);
+
+    const { drinks } = response.data;
+
+    return {
+      data: drinks || [],
+    };
+  } catch {
+    return { error: "Failed to search results" };
   }
 };

--- a/api/constants.ts
+++ b/api/constants.ts
@@ -3,3 +3,6 @@ export const RANDOM_COCKTAIL_ENDPOINT =
 
 export const COCKTAIL_DETAILS_ENDPOINT =
   "https://www.thecocktaildb.com/api/json/v1/1/lookup.php";
+
+export const COCKTAIL_SEARCH_ENDPOINT =
+  "https://www.thecocktaildb.com/api/json/v1/1/search.php";

--- a/components/shared/CocktailSearch.tsx
+++ b/components/shared/CocktailSearch.tsx
@@ -1,0 +1,104 @@
+import { Pressable, StyleSheet, TextInput, View, Text } from "react-native";
+import { useTheme } from "../providers/ThemeProvider";
+import { useState } from "react";
+import { Search, XIcon } from "lucide-react-native";
+
+interface CocktailSearch {
+  onSearch: (value: string) => Promise<void>;
+  onClear: () => void;
+  showClear: boolean;
+}
+
+export default function CocktailSearch({
+  onSearch,
+  onClear,
+  showClear,
+}: CocktailSearch) {
+  const [search, setSearch] = useState("");
+  const { colors, fonts } = useTheme();
+
+  const handleOnClear = () => {
+    setSearch("");
+    onClear();
+  };
+
+  return (
+    <View style={styles.searchInputContainer}>
+      <TextInput
+        style={{
+          ...styles.searchInput,
+          backgroundColor: colors.light,
+          fontFamily: fonts.regular,
+        }}
+        value={search}
+        placeholder="Search for a cocktail..."
+        placeholderTextColor="rgba(0, 0, 0, 0.3)"
+        onChangeText={setSearch}
+        returnKeyType="search"
+        onSubmitEditing={() => onSearch(search)}
+      />
+      <Pressable
+        onPress={() => onSearch(search)}
+        style={{ ...styles.searchButton, backgroundColor: colors.darkPink }}
+      >
+        <Search color={colors.light} />
+      </Pressable>
+      {showClear && (
+        <View style={styles.clearSearchButtonContainer}>
+          <Pressable
+            onPress={handleOnClear}
+            style={{
+              ...styles.clearSearchButton,
+              backgroundColor: colors.darkPink,
+            }}
+          >
+            <XIcon color={colors.light} size={20} />
+            <Text style={{ fontFamily: fonts.bold, color: colors.light }}>
+              Clear search
+            </Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  searchInputContainer: {
+    position: "relative",
+  },
+  searchInput: {
+    height: 45,
+    borderRadius: 20,
+    margin: 12,
+    fontSize: 18,
+    borderWidth: 1,
+    paddingHorizontal: 20,
+  },
+  searchButton: {
+    position: "absolute",
+    top: 10,
+    right: 10,
+    borderRadius: 50,
+    width: 48,
+    height: 48,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  clearSearchButtonContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  clearSearchButton: {
+    flexDirection: "row",
+    gap: 6,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    fontSize: 18,
+    borderRadius: 20,
+    marginBottom: 6,
+  },
+});

--- a/components/shared/EmptySearchResults.tsx
+++ b/components/shared/EmptySearchResults.tsx
@@ -1,0 +1,26 @@
+import { StyleSheet, Text, View } from "react-native";
+import { Search } from "lucide-react-native";
+import { useTheme } from "../providers/ThemeProvider";
+
+export default function EmptySearchResults() {
+  const { colors, fonts } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <Search color={colors.darkPink} size={80} strokeWidth={1.3} />
+      <Text style={{ ...styles.message, fontFamily: fonts.regular }}>
+        No results
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  message: {
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
Implemented cocktail search on the home page with the following logic:

Display random cocktails initially.

If a search has been executed, use the results from this, or display that there's no search results.

Once the search is cleared, go back to the random cocktails view.